### PR TITLE
Ask to update ToC when opening the document

### DIFF
--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.Shared/Word/WordManager.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.Shared/Word/WordManager.cs
@@ -95,6 +95,19 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word
 
         #endregion
 
+        #region Settings
+
+        /// <summary>
+        /// Force or not the update of Table of Content when the document is opened
+        /// </summary>
+        /// <param name="updateToc"></param>
+        public void SetToCUpdate(bool updateToc)
+        {
+            wdMainDocumentPart?.DocumentSettingsPart?.Settings?.Append(new UpdateFieldsOnOpen() { Val = new OnOffValue(updateToc) });
+        }
+
+        #endregion
+
         #region Fonctions privées - Open/Save/Create
 
         /// <summary>

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK/Word/IWordManager.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK/Word/IWordManager.cs
@@ -78,6 +78,16 @@ namespace MvvX.Plugins.OpenXMLSDK.Word
 
         #endregion
 
+        #region Settings
+
+        /// <summary>
+        /// Force or not the update of Table of Content when the document is opened
+        /// </summary>
+        /// <param name="updateToc"></param>
+        void SetToCUpdate(bool updateToc);
+
+        #endregion
+
         #region Open / Save / Close
 
         /// <summary>


### PR DESCRIPTION
If UpdateFieldsOnOpen is true, ask the user when opening the document if links have to be updated (in this case, if table of contents have to be updated)