### PR TITLE
Adding BeforeRows and AfterRows on table and UniformGrid

### DIFF
--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.Shared/Word/ReportEngine/TableExtensions.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.Shared/Word/ReportEngine/TableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
@@ -25,6 +26,9 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word.ReportEngine
             var wordTable = createdTable.Item1;
             var tableLook = createdTable.Item2;
 
+            // Before rows :
+            ManageBeforeAfterRows(table, table.BeforeRows, wordTable, context, documentPart);
+
             // add content rows
             if (!string.IsNullOrEmpty(table.DataSourceKey))
             {
@@ -49,6 +53,10 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word.ReportEngine
                 }
             }
 
+            // After rows :
+            ManageBeforeAfterRows(table, table.AfterRows, wordTable, context, documentPart);
+
+            // Footer
             ManageFooterRow(table, wordTable, tableLook, context, documentPart);
 
             parent.AppendChild(wordTable);
@@ -110,7 +118,7 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word.ReportEngine
             return new Tuple<Table, TableLook>(wordTable, tableLook);
         }
 
-        internal static void ManageFooterRow(OpenXMLSDK.Word.ReportEngine.Models.Table table, Table wordTable , TableLook tableLook, ContextModel context, OpenXmlPart documentPart)
+        internal static void ManageFooterRow(OpenXMLSDK.Word.ReportEngine.Models.Table table, Table wordTable, TableLook tableLook, ContextModel context, OpenXmlPart documentPart)
         {
             // add footer row
             if (table.FooterRow != null)
@@ -118,6 +126,19 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word.ReportEngine
                 wordTable.AppendChild(table.FooterRow.Render(wordTable, context, documentPart, false));
 
                 tableLook.LastRow = OnOffValue.FromBoolean(true);
+            }
+        }
+
+        internal static void ManageBeforeAfterRows(OpenXMLSDK.Word.ReportEngine.Models.Table table, IList<OpenXMLSDK.Word.ReportEngine.Models.Row> rows, Table wordTable, ContextModel context, OpenXmlPart documentPart)
+        {
+            // After rows :
+            if (rows != null && rows.Count > 0)
+            {
+                foreach (var row in rows)
+                {
+                    row.InheritFromParent(table);
+                    wordTable.AppendChild(row.Render(wordTable, context, documentPart, false));
+                }
             }
         }
     }

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.Shared/Word/ReportEngine/UniformGridExtensions.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.Shared/Word/ReportEngine/UniformGridExtensions.cs
@@ -31,7 +31,10 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word.ReportEngine
                     var createdTable = TableExtensions.CreateTable(uniformGrid, context, documentPart);
                     var wordTable = createdTable.Item1;
                     var tableLook = createdTable.Item2;
-                    
+
+                    // Before rows :
+                    TableExtensions.ManageBeforeAfterRows(uniformGrid, uniformGrid.BeforeRows, wordTable, context, documentPart);
+
                     // Table of cells :
                     List<List<ContextModel>> rowsContentContexts = new List<List<ContextModel>>();
 
@@ -69,6 +72,9 @@ namespace MvvX.Plugins.OpenXMLSDK.Platform.Word.ReportEngine
 
                         i++;
                     }
+
+                    // After rows :
+                    TableExtensions.ManageBeforeAfterRows(uniformGrid, uniformGrid.AfterRows, wordTable, context, documentPart);
 
                     TableExtensions.ManageFooterRow(uniformGrid, wordTable, tableLook, context, documentPart);
 

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
@@ -150,7 +150,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                             {
                                 ChildElements = new List<BaseElement>()
                                 {
-                                    new Label() {Text = "Cell 2 - First label" },
+                                    new Label() { Text = "Cell 2 - First label" },
                                     new Image()
                                     {
                                         MaxHeight = 100,
@@ -184,7 +184,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                                 Justification = JustificationValues.Right,
                                 ChildElements = new List<BaseElement>()
                                 {
-                                    new Label() {Text = "cellule4" }
+                                    new Label() { Text = "cellule4" }
                                 }
                             }
                         }
@@ -207,7 +207,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                         {
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() {Text = "header2" }
+                                new Label() { Text = "header2" }
                             }
                         }
                 }
@@ -261,14 +261,14 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                             Shading = "FFA0FF",
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() {Text = "#Cell1#" }
+                                new Label() { Text = "#Cell1#" }
                             }
                         },
                         new Cell()
                         {
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() {Text = "#Cell2#" }
+                                new Label() { Text = "#Cell2#" }
                             }
                         }
                     }
@@ -418,7 +418,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                                         Path = @"..\..\Resources\Desert.jpg",
                                         ImagePartType = Packaging.ImagePartType.Jpeg
                                     },
-                                    new Label() { Text = "Cell 1 - Label in a cell" },
+                                    new Label() { Text = "Custom header" },
                                     new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - Second paragraph" } } }
                                 },
                                 Fusion = true
@@ -427,7 +427,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                             {
                                 ChildElements = new List<BaseElement>()
                                 {
-                                    new Label() {Text = "Cell 2 - First label" },
+                                    new Label() { Text = "Cell 2 - First label" },
                                     new Image()
                                     {
                                         MaxHeight = 100,
@@ -461,7 +461,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                                 Justification = JustificationValues.Right,
                                 ChildElements = new List<BaseElement>()
                                 {
-                                    new Label() {Text = "cellule4" }
+                                    new Label() { Text = "celluleX" }
                                 }
                             }
                         }
@@ -476,14 +476,14 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                             Shading = "FFA0FF",
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() {Text = "#Cell1#" }
+                                new Label() { Text = "#Cell1#" }
                             }
                         },
                         new Cell()
                         {
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() {Text = "#Cell2#" }
+                                new Label() { Text = "#Cell2#" }
                             }
                         }
                     }

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
@@ -440,8 +440,8 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                                 Borders = new Word.ReportEngine.Models.Attributes.BorderModel()
                                 {
                                     BorderColor = "00FF22",
-                                    BorderWidth = 20,
-                                    BorderPositions = Word.ReportEngine.Models.Attributes.BorderPositions.LEFT | Word.ReportEngine.Models.Attributes.BorderPositions.TOP
+                                    BorderWidth = 15,
+                                    BorderPositions = Word.ReportEngine.Models.Attributes.BorderPositions.RIGHT | Word.ReportEngine.Models.Attributes.BorderPositions.TOP
                                 }
                             }
                         }

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
@@ -387,6 +387,114 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
 
             doc.Pages.Add(page4);
 
+            var page5 = new Page();
+            var tableDataSourceWithBeforeAfter = new Table()
+            {
+                TableWidth = new TableWidthModel() { Width = "5000", Type = TableWidthUnitValues.Pct },
+                ColsWidth = new int[2] { 750, 4250 },
+                Borders = new Word.ReportEngine.Models.Attributes.BorderModel()
+                {
+                    BorderPositions = (Word.ReportEngine.Models.Attributes.BorderPositions)63,
+                    BorderColor = "328864",
+                    BorderWidth = 20,
+                },
+                BeforeRows = new List<Row>()
+                {
+                    new Row()
+                    {
+                        Cells = new List<Cell>()
+                        {
+                            new Cell()
+                            {
+                                VerticalAlignment = TableVerticalAlignmentValues.Center,
+                                Justification = JustificationValues.Center,
+                                ChildElements = new List<BaseElement>()
+                                {
+                                    new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - First paragraph" } }, ParagraphStyleId = "Yellow" },
+                                    new Image()
+                                    {
+                                        MaxHeight = 100,
+                                        MaxWidth = 100,
+                                        Path = @"..\..\Resources\Desert.jpg",
+                                        ImagePartType = Packaging.ImagePartType.Jpeg
+                                    },
+                                    new Label() { Text = "Cell 1 - Label in a cell" },
+                                    new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - Second paragraph" } } }
+                                },
+                                Fusion = true
+                            },
+                            new Cell()
+                            {
+                                ChildElements = new List<BaseElement>()
+                                {
+                                    new Label() {Text = "Cell 2 - First label" },
+                                    new Image()
+                                    {
+                                        MaxHeight = 100,
+                                        MaxWidth = 100,
+                                        Path = @"..\..\Resources\Desert.jpg",
+                                        ImagePartType = Packaging.ImagePartType.Jpeg
+                                    },
+                                    new Label() { Text = "Cell 2 - Second label" }
+                                },
+                                Borders = new Word.ReportEngine.Models.Attributes.BorderModel()
+                                {
+                                    BorderColor = "00FF00",
+                                    BorderWidth = 20,
+                                    BorderPositions = Word.ReportEngine.Models.Attributes.BorderPositions.LEFT | Word.ReportEngine.Models.Attributes.BorderPositions.TOP
+                                }
+                            }
+                        }
+                    },
+                    new Row()
+                    {
+                        Cells = new List<Cell>()
+                        {
+                            new Cell()
+                            {
+                                Fusion = true,
+                                FusionChild = true
+                            },
+                            new Cell()
+                            {
+                                VerticalAlignment = TableVerticalAlignmentValues.Bottom,
+                                Justification = JustificationValues.Right,
+                                ChildElements = new List<BaseElement>()
+                                {
+                                    new Label() {Text = "cellule4" }
+                                }
+                            }
+                        }
+                    }
+                },
+                RowModel = new Row()
+                {
+                    Cells = new List<Cell>()
+                    {
+                        new Cell()
+                        {
+                            Shading = "FFA0FF",
+                            ChildElements = new List<BaseElement>()
+                            {
+                                new Label() {Text = "#Cell1#" }
+                            }
+                        },
+                        new Cell()
+                        {
+                            ChildElements = new List<BaseElement>()
+                            {
+                                new Label() {Text = "#Cell2#" }
+                            }
+                        }
+                    }
+                },
+                DataSourceKey = "#Datasource#"
+            };
+
+            page5.ChildElements.Add(tableDataSourceWithBeforeAfter);
+
+            doc.Pages.Add(page5);
+
             // Header
             var header = new Header();
             header.Type = HeaderFooterValues.Default;

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK.TestConsole/Program.cs
@@ -406,11 +406,11 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                         {
                             new Cell()
                             {
-                                VerticalAlignment = TableVerticalAlignmentValues.Center,
-                                Justification = JustificationValues.Center,
+                                VerticalAlignment = TableVerticalAlignmentValues.Bottom,
+                                Justification = JustificationValues.Left,
                                 ChildElements = new List<BaseElement>()
                                 {
-                                    new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - First paragraph" } }, ParagraphStyleId = "Yellow" },
+                                    new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - A small paragraph" } }, ParagraphStyleId = "Yellow" },
                                     new Image()
                                     {
                                         MaxHeight = 100,
@@ -419,7 +419,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                                         ImagePartType = Packaging.ImagePartType.Jpeg
                                     },
                                     new Label() { Text = "Custom header" },
-                                    new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - Second paragraph" } } }
+                                    new Paragraph() { ChildElements = new List<BaseElement>() { new Label() { Text = "Cell 1 - an other paragraph" } } }
                                 },
                                 Fusion = true
                             },
@@ -427,7 +427,7 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                             {
                                 ChildElements = new List<BaseElement>()
                                 {
-                                    new Label() { Text = "Cell 2 - First label" },
+                                    new Label() { Text = "Cell 2 - an other label" },
                                     new Image()
                                     {
                                         MaxHeight = 100,
@@ -435,11 +435,11 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                                         Path = @"..\..\Resources\Desert.jpg",
                                         ImagePartType = Packaging.ImagePartType.Jpeg
                                     },
-                                    new Label() { Text = "Cell 2 - Second label" }
+                                    new Label() { Text = "Cell 2 - an other other label" }
                                 },
                                 Borders = new Word.ReportEngine.Models.Attributes.BorderModel()
                                 {
-                                    BorderColor = "00FF00",
+                                    BorderColor = "00FF22",
                                     BorderWidth = 20,
                                     BorderPositions = Word.ReportEngine.Models.Attributes.BorderPositions.LEFT | Word.ReportEngine.Models.Attributes.BorderPositions.TOP
                                 }
@@ -473,17 +473,17 @@ namespace MvvX.Plugins.OpenXMLSDK.TestConsole
                     {
                         new Cell()
                         {
-                            Shading = "FFA0FF",
+                            Shading = "FFA2FF",
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() { Text = "#Cell1#" }
+                                new Label() { Text = "Cell : #Cell1#" }
                             }
                         },
                         new Cell()
                         {
                             ChildElements = new List<BaseElement>()
                             {
-                                new Label() { Text = "#Cell2#" }
+                                new Label() { Text = "Cell : #Cell2#" }
                             }
                         }
                     }

--- a/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK/Word/ReportEngine/Models/Table.cs
+++ b/MvvX.Plugins.Open-XML-SDK/MvvX.Plugins.Open-XML-SDK/Word/ReportEngine/Models/Table.cs
@@ -10,10 +10,22 @@ namespace MvvX.Plugins.OpenXMLSDK.Word.ReportEngine.Models
     public class Table : BaseElement
     {
         /// <summary>
+        /// Rows of the table, generated before Rows field content
+        /// used only if the table is not binded to a datasource (DataSourceKey != null)
+        /// </summary>
+        public IList<Row> BeforeRows { get; set; } = new List<Row>();
+
+        /// <summary>
         /// Rows of the table
         /// used only if the table is not binded to a datasource (DataSourceKey != null)
         /// </summary>
         public IList<Row> Rows { get; set; } = new List<Row>();
+
+        /// <summary>
+        /// Rows of the table, generated after Rows field content
+        /// used only if the table is not binded to a datasource (DataSourceKey != null)
+        /// </summary>
+        public IList<Row> AfterRows { get; set; } = new List<Row>();
 
         /// <summary>
         /// if bind to a datasource, contains the model of a row


### PR DESCRIPTION
Adding BeforeRows and AfterRows that allow to create custom headers and footers with colspan and rowspan, even if you bind a datasource to the table or UniformGrid